### PR TITLE
add share async and mediate library to set state for functionality to…

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,21 +1,105 @@
-import { React } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
-import CameraScreen from './CameraScreen'
+import { StatusBar } from "expo-status-bar";
+import {
+  StyleSheet,
+  Text,
+  View,
+  SafeAreaView,
+  Button,
+  Image,
+} from "react-native";
+import { useEffect, useRef, useState } from "react";
+import { Camera } from "expo-camera";
+import { shareAsync } from "expo-sharing";
+import * as MediaLibrary from "expo-media-library";
 
 export default function App() {
+  let cameraRef = useRef();
+  const [hasCameraPermission, setHasCameraPermission] = useState();
+  const [hasMediaLibraryPermission, setHasMediaLibraryPermission] = useState();
+  const [photo, setPhoto] = useState();
+
+  useEffect(() => {
+    (async () => {
+      const cameraPermission = await Camera.requestCameraPermissionsAsync();
+      const mediaLibraryPermission =
+        await MediaLibrary.requestPermissionsAsync();
+      setHasCameraPermission(cameraPermission.status === "granted");
+      setHasMediaLibraryPermission(mediaLibraryPermission.status === "granted");
+    })();
+  }, []);
+
+  if (hasCameraPermission === undefined) {
+    return <Text>Requesting permissions...</Text>;
+  } else if (!hasCameraPermission) {
+    return (
+      <Text>
+        Permission for camera not granted. Please change this in settings my friend 
+      </Text>
+    );
+  }
+
+  let takePic = async () => {
+    let options = {
+      quality: 1,
+      base64: true,
+      exif: false,
+    };
+
+    let newPhoto = await cameraRef.current.takePictureAsync(options);
+    setPhoto(newPhoto);
+  };
+
+  if (photo) {
+    let sharePic = () => {
+      shareAsync(photo.uri).then(() => {
+        setPhoto(undefined);
+      });
+    };
+
+    let savePhoto = () => {
+      MediaLibrary.saveToLibraryAsync(photo.uri).then(() => {
+        setPhoto(undefined);
+      });
+    };
+
+    return (
+      <SafeAreaView style={styles.container}>
+        <Image
+          style={styles.preview}
+          source={{ uri: "data:image/jpg;base64," + photo.base64 }}
+        />
+        <Button title="Share" onPress={sharePic} />
+        {hasMediaLibraryPermission ? (
+          <Button title="Save" onPress={savePhoto} />
+        ) : undefined}
+        <Button title="Discard" onPress={() => setPhoto(undefined)} />
+      </SafeAreaView>
+    );
+  }
+
   return (
-    <View style={styles.container}>
-      <CameraScreen/>
-      <Text>Text Extractor</Text>
-    </View>
+    <Camera style={styles.container} ref={cameraRef}>
+      <View style={styles.buttonContainer}>
+        <Button title="Take Pic" onPress={takePic} />
+      </View>
+      <StatusBar style="auto" />
+      <Text>Text-Extractor</Text>
+    </Camera>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  buttonContainer: {
+    backgroundColor: "#fff",
+    alignSelf: "flex-end",
+  },
+  preview: {
+    alignSelf: "stretch",
+    flex: 1,
   },
 });

--- a/CameraScreen.js
+++ b/CameraScreen.js
@@ -1,43 +1,81 @@
-import React, { useRef, useState, useEffect } from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
-import { Camera } from 'expo-camera';
-import * as Permissions from 'expo-permissions';
+// import React, { useRef, useState, useEffect } from 'react';
+// import { View, Text, TouchableOpacity, SafeAreaView, Button, Image } from 'react-native';
+// import { Camera } from 'expo-camera';
+// import * as Permissions from 'expo-permissions';
+// import {shareAsync} from 'expo-sharing'
 
-const CameraScreen = () => {
-  const cameraRef = useRef(null);
-  const [hasPermission, setHasPermission] = useState(null);
+// const CameraScreen = () => {
+//   const cameraRef = useRef(null);
+//   const [hasPermission, setHasPermission] = useState(null);
+//   const [hasMediaLibarayPermission, setHasMediaLibraryPermission] = useState()
+//   const [photo, setPhoto] = useState()
 
-  useEffect(() => {
-    (async () => {
-      const { status } = await Permissions.askAsync(Permissions.CAMERA);
-      setHasPermission(status === 'granted');
-    })();
-  }, []);
+//   useEffect(() => {
+//     (async () => {
+//       const { status } = await Permissions.askAsync(Permissions.CAMERA);
+//       setHasPermission(status === 'granted');
+//       setHasMediaLibraryPermission(mediaLibrary.status === 'granted')
+//     })();
+//   }, []);
 
-  const takePicture = async () => {
-    if (cameraRef.current) {
-      const photo = await cameraRef.current.takePictureAsync();
-      console.log('Picture data:', photo);
-      // You can do something with the photo data, like displaying the image or uploading it.
-    }
-  };
+//   if(hasPermission === undefinied) {
+//     return <Text>Requesting permissions</Text>
+//   } else if(!cameraPermission) {
+//     return <Text>Permission for camera not granted</Text>
+//   }
 
-  if (hasPermission === null) {
-    return <View />;
-  }
-  if (hasPermission === false) {
-    return <Text>No access to camera</Text>;
-  }
+//   const takePicture = async () => {
+//     let options = {
+//       quality:1,
+//       base64: true,
+//       exif: false,
+//     };
+//     if (cameraRef.current) {
+//       const photo = await cameraRef.current.takePictureAsync(options);
+//       console.log('Picture data:', photo);
+//       // You can do something with the photo data, like displaying the image or uploading it.
+//     }
+//     if(photo) {
+//       let sharePic = () => {
 
-  return (
-    <View style={{ flex: 1 }}>
-      <Camera ref={cameraRef} style={{ flex: 1, aspectRatio: 4/3 }} type={Camera.Constants.Type.back}>
-        <TouchableOpacity onPress={takePicture} style={{ alignSelf: 'center', margin: 20 }}>
-          <Text style={{ fontSize: 20, color: 'white' }}>Take Photo</Text>
-        </TouchableOpacity>
-      </Camera>
-    </View>
-  );
-};
+//       }
+//       let savePhoto = () => {
 
-export default CameraScreen;
+//       }
+//       return (
+//       <SafeAreaView styles={styles.container}>
+//         <Image
+
+//       </SafeAreaView>
+//         )
+//     }
+//   };
+
+//   if (hasPermission === null) {
+//     return <View />;
+//   }
+//   if (hasPermission === false) {
+//     return <Text>No access to camera</Text>;
+//   }
+
+//   return (
+//     <View style={{ flex: 1 }}>
+//       <Camera ref={cameraRef} style={{ flex: 1, aspectRatio: 4/3 }} type={Camera.Constants.Type.back}>
+//         <View style={StyleSheet.buttonContainer}></View>
+//         <TouchableOpacity onPress={takePicture} style={{ alignSelf: 'center', margin: 20 }}>
+//           <Text style={{ fontSize: 20, color: 'white' }}>Take Photo</Text>
+//         </TouchableOpacity>
+//       </Camera>
+//     </View>
+//   );
+// };
+
+// const styles = StyleSheet.create({
+//   container: {
+//     flex:1,
+//     alignItems:'center',
+//     justifyContent
+//   }
+// })
+
+// export default CameraScreen;

--- a/app.json
+++ b/app.json
@@ -1,36 +1,40 @@
 {
   "expo": {
-    "name": "text-extractor",
-    "slug": "text-extractor",
+    "name": "CameraAppTutorial",
+    "slug": "CameraAppTutorial",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": [
-      "**/*"
+    "plugins": [
+      [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos.",
+          "isAccessMediaLocationEnabled": "true"
+        }
+      ]
     ],
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
+        "backgroundColor": "#FFFFFF"
       }
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    },
-    "extra": {
-      "eas": {
-        "projectId": "067929e2-745b-4865-81f5-b64e73a0ad14"
-      }
-    },
-    "owner": "dgouner"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "expo": "~48.0.18",
         "expo-camera": "~13.2.1",
+        "expo-media-library": "~15.2.3",
         "expo-permissions": "~14.1.1",
+        "expo-sharing": "~11.2.2",
         "expo-status-bar": "~1.4.4",
         "react": "18.2.0",
         "react-native": "0.71.8",
@@ -6994,6 +6996,14 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-media-library": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-15.2.3.tgz",
+      "integrity": "sha512-Oz8b8Xsvfj7YcutUBtI84NUIqSnt7iCM5HZ5DyKoWKKiDK/+aUuj3RXNQELG8jUw6pQPgEwgbZ1+J8SdH/y9jw==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.2.0.tgz",
@@ -7119,6 +7129,14 @@
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/expo-permissions/-/expo-permissions-14.1.2.tgz",
       "integrity": "sha512-NcozPs0cPDe65/Kc7yhSbdGcdpEIeEK1VcUlhRmOrC3kEahwlIdmyLdfhtuuUggaB75Wlo7VOGMZrsNHTWOVHw==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-11.2.2.tgz",
+      "integrity": "sha512-4Lhm1eS/CFIzX+JPuxMUTWBt9rv/WdvJvpQ9y+71bL/9w9dhvsdt9tv0SsNZATz4hk0tbrYD8ZEUsgiHiT1KkQ==",
       "peerDependencies": {
         "expo": "*"
       }
@@ -19028,6 +19046,12 @@
       "integrity": "sha512-hqeCnb4033TyuZaXs93zTK7rjVJ3bywXATyMmKmKkLEsH2PKBAl/VmjlCOPQL/2Ncqz6aj7Wo//tjeJTARBD4g==",
       "requires": {}
     },
+    "expo-media-library": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-15.2.3.tgz",
+      "integrity": "sha512-Oz8b8Xsvfj7YcutUBtI84NUIqSnt7iCM5HZ5DyKoWKKiDK/+aUuj3RXNQELG8jUw6pQPgEwgbZ1+J8SdH/y9jw==",
+      "requires": {}
+    },
     "expo-modules-autolinking": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.2.0.tgz",
@@ -19123,6 +19147,12 @@
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/expo-permissions/-/expo-permissions-14.1.2.tgz",
       "integrity": "sha512-NcozPs0cPDe65/Kc7yhSbdGcdpEIeEK1VcUlhRmOrC3kEahwlIdmyLdfhtuuUggaB75Wlo7VOGMZrsNHTWOVHw==",
+      "requires": {}
+    },
+    "expo-sharing": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-11.2.2.tgz",
+      "integrity": "sha512-4Lhm1eS/CFIzX+JPuxMUTWBt9rv/WdvJvpQ9y+71bL/9w9dhvsdt9tv0SsNZATz4hk0tbrYD8ZEUsgiHiT1KkQ==",
       "requires": {}
     },
     "expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "rn-text-detector": "^0.0.8",
     "tesseract.js": "^4.1.1",
     "expo-camera": "~13.2.1",
-    "expo-permissions": "~14.1.1"
+    "expo-permissions": "~14.1.1",
+    "expo-sharing": "~11.2.2",
+    "expo-media-library": "~15.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
- Add camera permissions and media library permissions using the useState hook.
- If the camera permission is granted, the camera view is displayed with a "Take Pic" button. When a photo is captured, it is stored in the photo state variable, and the view changes to show the captured photo along with "Share," "Save," and "Discard" buttons. 
- sharePic function uses the shareAsync function from expo-sharing to share the captured photo
- savePhoto function uses the saveToLibraryAsync function from expo-media-library to save the photo to the device's media library. 

